### PR TITLE
Broaden python version compatibility

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,16 +11,16 @@ source:
   sha256: 47f68007ceca4d385166f7214e957148e0262814c64bac892ebe5f2da7593fa3
 
 build:
-  number: 1
+  number: 2
   script: '{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv '
   noarch: python
 
 requirements:
   host:
-    - python =2.7|3.6|3.7|3.8|3.9|3.10|3.11|3.12 #ignore pypy
+    - python =2.7.* | >=3.6
     - pip
   run:
-    - python =2.7|3.6|3.7|3.8|3.9|3.10|3.11|3.12 #ignore pypy
+    - python =2.7.* | >=3.6
 
 test:
   imports:


### PR DESCRIPTION
Sorry about the rapidfire PRs, but after trying out the new version I realized it was less than satisfactory.

The previous 3.6|3.7|... expression was using *exact matches*, i.e. 3.7 really means 3.7.0 and NOT 3.7.*. Thus installing the resulting package in a 3.11.6 environment resulted in the env being downgraded to 3.11.0!

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
